### PR TITLE
Sync bulk selection with visible rows

### DIFF
--- a/src/app/static/js/utils/bulkActions.js
+++ b/src/app/static/js/utils/bulkActions.js
@@ -36,10 +36,28 @@ export function setupBulkActions(config = {}) {
     return;
   }
 
-  // Actualizar estado de los botones
-  function updateBulkButtons() {
-    const anyChecked = Array.from(checkboxes).some(cb => cb.checked);
-    
+  function getVisibleCheckboxes() {
+    return Array.from(checkboxes).filter(cb => {
+      const row = cb.closest('tr');
+      if (!row) {
+        return false;
+      }
+      return getComputedStyle(row).display !== 'none';
+    });
+  }
+
+  // Actualizar estado de los botones y seleccionar todo
+  function updateSelectionState() {
+    const visibleCheckboxes = getVisibleCheckboxes();
+    const anyChecked = visibleCheckboxes.some(cb => cb.checked);
+    const allChecked = visibleCheckboxes.length > 0 && visibleCheckboxes.every(cb => cb.checked);
+
+    if (selectAll) {
+      selectAll.checked = allChecked;
+      selectAll.indeterminate = anyChecked && !allChecked;
+      selectAll.disabled = visibleCheckboxes.length === 0;
+    }
+
     // Usamos clases para manejar visibilidad
     if (anyChecked) {
       bulkDisable.classList.add(visibleClass);
@@ -48,31 +66,31 @@ export function setupBulkActions(config = {}) {
       bulkDisable.classList.remove(visibleClass);
       bulkRecover.classList.remove(visibleClass);
     }
-    
+
     bulkDisable.disabled = !anyChecked;
     bulkRecover.disabled = !anyChecked;
   }
 
   // Inicializar
-  updateBulkButtons();
+  updateSelectionState();
 
   // Evento para seleccionar/deseleccionar todos
   if (selectAll) {
     selectAll.addEventListener('change', () => {
-      checkboxes.forEach(cb => cb.checked = selectAll.checked);
-      updateBulkButtons();
+      getVisibleCheckboxes().forEach(cb => cb.checked = selectAll.checked);
+      updateSelectionState();
     });
   }
 
   // Eventos para checkboxes individuales
   checkboxes.forEach(cb => {
     cb.addEventListener('change', () => {
-      // Actualizar estado de "seleccionar todos"
-      if (selectAll) {
-        selectAll.checked = Array.from(checkboxes).every(cb => cb.checked);
-      }
-      updateBulkButtons();
+      updateSelectionState();
     });
+  });
+
+  document.addEventListener('bulk-selection-refresh', () => {
+    updateSelectionState();
   });
 
   // Deshabilitar botones al enviar

--- a/src/app/static/js/utils/tableSearch.js
+++ b/src/app/static/js/utils/tableSearch.js
@@ -13,7 +13,9 @@ export function initTableSearch(config) {
         resultsCountId,
         tableBodyId,
         searchColumns,
-        filterConfigs
+        filterConfigs,
+        rowCheckboxSelector = '.select-row',
+        clearSelectionOnHide = true
     } = config;
 
     // Elementos DOM
@@ -115,11 +117,17 @@ export function initTableSearch(config) {
             visibleCount++;
         } else {
             row.style.display = 'none';
+            const rowCheckbox = row.querySelector(rowCheckboxSelector);
+            if (clearSelectionOnHide && rowCheckbox && rowCheckbox.checked) {
+                rowCheckbox.checked = false;
+            }
         }
     });
 
     // Actualizar UI de resultados
     updateResultsUI(searchTerm, visibleCount);
+
+    document.dispatchEvent(new CustomEvent('bulk-selection-refresh'));
 }
 
     /**


### PR DESCRIPTION
Make bulk action controls consider only visible rows and keep the select-all checkbox state in sync with filtering. bulkActions.js: add getVisibleCheckboxes() and updateSelectionState() to compute any/all checked among visible rows, set selectAll.indeterminate and disabled when appropriate, update handlers to operate on visible checkboxes, and listen for a 'bulk-selection-refresh' event. tableSearch.js: add config options rowCheckboxSelector and clearSelectionOnHide (default true); uncheck row checkbox when a row is hidden by filtering and dispatch the refresh event so bulk controls update. This prevents hidden/filtered-out rows from affecting bulk actions and keeps UI consistent.