### PR TITLE
Fix country-indicator permissions and UI

### DIFF
--- a/src/app/forms/country_indicator_form.py
+++ b/src/app/forms/country_indicator_form.py
@@ -1,7 +1,7 @@
 from flask_wtf import FlaskForm
 from flask_babel import lazy_gettext as _l
 from wtforms import SelectField, BooleanField, SubmitField, TextAreaField, StringField
-from wtforms.validators import DataRequired, Optional
+from wtforms.validators import DataRequired, Optional, Length
 import json
 from wtforms import ValidationError
 
@@ -49,12 +49,12 @@ class CountryIndicatorForm(FlaskForm):
 
     store = StringField(
         _l('Store'),
-        validators=[Optional()]
+        validators=[Optional(), Length(max=255)]
     )
 
     workspace = StringField(
         _l('Workspace'),
-        validators=[Optional()]
+        validators=[Optional(), Length(max=255)]
     )
 
     submit = SubmitField(_l('Guardar'))

--- a/src/app/routes/country_indicator_routes.py
+++ b/src/app/routes/country_indicator_routes.py
@@ -55,7 +55,7 @@ def list_country_indicator():
                 criteria=criteria_data,
                 description=form.description.data or None,
                 store=form.store.data or None,
-                workspace=form.workspace.data or None
+                workspace=form.workspace.data or None,
             )
             country_indicator_service.create(new_ci)
             flash(_('Relación país-indicador agregada correctamente.'), 'success')
@@ -86,6 +86,8 @@ def edit_country_indicator(id):
     if request.method == 'GET':
         form.country_id.data = str(ci.country_id)
         form.indicator_id.data = ci.indicator_id
+        if ci.criteria:
+            form.criteria.data = json.dumps(ci.criteria, ensure_ascii=False)
 
     if form.validate_on_submit():
         # Validar y convertir el campo criteria si existe
@@ -102,8 +104,6 @@ def edit_country_indicator(id):
         
         try:
             update_data = CountryIndicatorUpdate(
-                country_id=int(form.country_id.data),
-                indicator_id=form.indicator_id.data,
                 spatial_forecast=form.spatial_forecast.data,
                 spatial_climate=form.spatial_climate.data,
                 location_forecast=form.location_forecast.data,
@@ -111,7 +111,7 @@ def edit_country_indicator(id):
                 criteria=criteria_data,
                 description=form.description.data or None,
                 store=form.store.data or None,
-                workspace=form.workspace.data or None
+                workspace=form.workspace.data or None,
             )
             country_indicator_service.update(id=id, obj_in=update_data)
             flash(_('Relación país-indicador actualizada.'), 'success')

--- a/src/app/routes/country_routes.py
+++ b/src/app/routes/country_routes.py
@@ -72,7 +72,7 @@ def edit_country(id):
             iso2=form.iso2.data.upper(),
             enable=form.enable.data
         )
-
+        country_service.update(id=id, obj_in=update)
         flash(_('País actualizado correctamente.'), 'success')
         return redirect(url_for('country.list_country'))
 

--- a/src/app/static/js/base.js
+++ b/src/app/static/js/base.js
@@ -80,9 +80,14 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Mapeo de rutas a secciones del sidebar
     // IMPORTANTE: Rutas más específicas primero (ej: country_indicator antes de country)
+    // IMPORTANTE: rutas más específicas siempre antes que sus prefijos
     const routeSectionMap = {
+      // Indicadores (antes de Geográfico para que country_indicator no matchee con 'country')
+      country_indicator: "indicatorsSection",
+      indicator_features: "indicatorsSection",
+      indicator_category: "indicatorsSection",
+      indicator: "indicatorsSection",
       // Geográfico
-      country_indicator: "configurationSection",  // Debe ir ANTES de country
       country: "geograficoSection",
       adm1: "geograficoSection",
       adm2: "geograficoSection",
@@ -90,8 +95,9 @@ document.addEventListener("DOMContentLoaded", function () {
       // Clima
       weather: "climaSection",
       climate: "climaSection",
-      // Cultivos
-      phenological_stage: "cultivosSection",  // Debe ir antes que otros para evitar matches parciales
+      // Cultivos (phenological_stage antes de stress para evitar match parcial con phenological_stage_stress)
+      phenological_stage_stress: "cultivosSection",
+      phenological_stage: "cultivosSection",
       crop: "cultivosSection",
       stress: "cultivosSection",
       cultivar: "cultivosSection",
@@ -100,13 +106,11 @@ document.addEventListener("DOMContentLoaded", function () {
       setup: "cultivosSection",
       simulation: "cultivosSection",
       parameter: "cultivosSection",
-      // Indicadores
-      indicator_category: "indicatorsSection",  // Debe ir ANTES de indicator
-      indicator: "indicatorsSection",
       // Usuarios
       user: "usuariosSection",
       role: "usuariosSection",
       // Configuración
+      app:"configurationSection",
       data_source: "configurationSection",
       source: "configurationSection",
     };

--- a/src/app/templates/base.html
+++ b/src/app/templates/base.html
@@ -287,6 +287,18 @@
             >
               <span>{{ _('Gestión de categorías de indicadores') }}</span>
             </a>
+             <a
+              class="nav-link d-flex align-items-center text-dark"
+              href="{{ url_for('country_indicator.list_country_indicator') }}"
+            >
+              <span>{{ _('Indicadores por país') }}</span>
+            </a>
+            <a
+              class="nav-link d-flex align-items-center text-dark"
+              href="{{ url_for('indicator_features.list_indicator_features') }}"
+            >
+              <span>{{ _('Características de indicadores') }}</span>
+            </a>
           </nav>
         </div>
       </div>
@@ -361,24 +373,7 @@
             >
               <span>{{ _('Parámetros de clientes') }}</span>
             </a>
-            <a
-              class="nav-link d-flex align-items-center text-dark"
-              href="{{ url_for('country_indicator.list_country_indicator') }}"
-            >
-              <span>{{ _('Indicadores por país') }}</span>
-            </a>
-            <a
-              class="nav-link d-flex align-items-center text-dark"
-              href="{{ url_for('country_climate_measure.list_country_climate_measure') }}"
-            >
-              <span>{{ _('Medidas climáticas por país') }}</span>
-            </a>
-            <a
-              class="nav-link d-flex align-items-center text-dark"
-              href="{{ url_for('indicator_features.list_indicator_features') }}"
-            >
-              <span>{{ _('Características de indicadores') }}</span>
-            </a>
+           
           </nav>
         </div>
       </div>

--- a/src/app/templates/country_indicator/edit.html
+++ b/src/app/templates/country_indicator/edit.html
@@ -56,26 +56,33 @@
 
     <div class="mb-3">
       {{ form.description.label(class="form-label") }}
+      <small class="text-muted ms-1">— {{ _('Si se deja vacío, se usa la descripción del indicador') }}</small>
+      {% if country_indicator.indicator and country_indicator.indicator.description %}
+      <div class="form-text text-muted mb-1">
+        <strong>{{ _('Descripción del indicador:') }}</strong> {{ country_indicator.indicator.description }}
+      </div>
+      {% endif %}
       {{ form.description(class="form-control") }}
       {% for error in form.description.errors %}
         <div class="text-danger">{{ error }}</div>
       {% endfor %}
     </div>
 
-    <div class="mb-3">
-      {{ form.store.label(class="form-label") }}
-      {{ form.store(class="form-control") }}
-      {% for error in form.store.errors %}
-        <div class="text-danger">{{ error }}</div>
-      {% endfor %}
-    </div>
-
-    <div class="mb-3">
-      {{ form.workspace.label(class="form-label") }}
-      {{ form.workspace(class="form-control") }}
-      {% for error in form.workspace.errors %}
-        <div class="text-danger">{{ error }}</div>
-      {% endfor %}
+    <div class="row">
+      <div class="col-md-6 mb-3">
+        {{ form.store.label(class="form-label") }}
+        {{ form.store(class="form-control") }}
+        {% for error in form.store.errors %}
+          <div class="text-danger">{{ error }}</div>
+        {% endfor %}
+      </div>
+      <div class="col-md-6 mb-3">
+        {{ form.workspace.label(class="form-label") }}
+        {{ form.workspace(class="form-control") }}
+        {% for error in form.workspace.errors %}
+          <div class="text-danger">{{ error }}</div>
+        {% endfor %}
+      </div>
     </div>
 
     {{ form.submit(class="btn btn-success") }}

--- a/src/app/templates/country_indicator/list.html
+++ b/src/app/templates/country_indicator/list.html
@@ -51,7 +51,7 @@
 
   {% if country_indicators %}
   <div id="countryIndicatorTableContainer" class="table-responsive">
-    {% if current_user.has_module_access('configuration', 'delete') %}
+    {% if current_user.has_module_access('INDICATORS_DATA', 'delete') %}
     <form id="bulk-action-form" method="POST" action="{{ url_for('country_indicator.bulk_action') }}">
       <div class="mb-2">
         <input type="hidden" name="action" id="bulk-action-hidden" value="" />
@@ -63,7 +63,7 @@
       <table class="table table-hover align-middle table-sm">
         <thead class="table-light">
           <tr>
-            {% if current_user.has_module_access('configuration', 'delete') %}
+            {% if current_user.has_module_access('INDICATORS_DATA', 'delete') %}
             <th style="width: 40px; min-width: 40px;"><input type="checkbox" id="select-all" /></th>
             {% endif %}
             <th style="width: 10%; min-width: 100px;">{{ _('País') }}</th>
@@ -73,10 +73,10 @@
             <th style="width: 12%; min-width: 120px; text-align: center;">{{ _('Pronóstico por ubicación') }}</th>
             <th style="width: 12%; min-width: 120px; text-align: center;">{{ _('Clima por ubicación') }}</th>
             <th style="width: 14%; min-width: 100px;">{{ _('Criterios') }}</th>
-            <th style="width: 14%; min-width: 100px;">{{ _('Descripción') }}</th>
-            <th style="width: 8%; min-width: 80px;">{{ _('Store') }}</th>
-            <th style="width: 8%; min-width: 80px;">{{ _('Workspace') }}</th>
-            {% if current_user.has_module_access('configuration', 'update') or current_user.has_module_access('configuration', 'delete') %}
+            <th style="width: 16%; min-width: 120px;">{{ _('Descripción') }}</th>
+            <th style="width: 10%; min-width: 90px;">{{ _('Store') }}</th>
+            <th style="width: 10%; min-width: 90px;">{{ _('Workspace') }}</th>
+            {% if current_user.has_module_access('INDICATORS_DATA', 'update') or current_user.has_module_access('INDICATORS_DATA', 'delete') %}
             <th class="text-end" style="width: 12%; min-width: 100px;">{{ _('Acciones') }}</th>
             {% endif %}
           </tr>
@@ -84,7 +84,7 @@
         <tbody id="countryIndicatorTableBody">
           {% for ci in country_indicators %}
           <tr>
-            {% if current_user.has_module_access('configuration', 'delete') %}
+            {% if current_user.has_module_access('INDICATORS_DATA', 'delete') %}
             <td><input type="checkbox" name="selected_ids" value="{{ ci.id }}" class="select-row" /></td>
             {% endif %}
             <td class="searchable country">{{ ci.country.name if ci.country else '' }}</td>
@@ -94,12 +94,17 @@
             <td class="searchable location_forecast text-center">{{ _('Sí') if ci.location_forecast else _('No') }}</td>
             <td class="searchable location_climate text-center">{{ _('Sí') if ci.location_climate else _('No') }}</td>
             <td class="searchable criteria">{{ ci.criteria or '' }}</td>
-            <td class="searchable description">{{ ci.description or '' }}</td>
+            <td class="searchable description" style="max-width: 180px;">
+              {% set desc = ci.description or (ci.indicator.description if ci.indicator else '') %}
+              {% if desc %}
+              <span title="{{ desc }}" style="display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;">{{ desc }}</span>
+              {% endif %}
+            </td>
             <td class="searchable store">{{ ci.store or '' }}</td>
             <td class="searchable workspace">{{ ci.workspace or '' }}</td>
-            {% if current_user.has_module_access('configuration', 'update') or current_user.has_module_access('configuration', 'delete') %}
+            {% if current_user.has_module_access('INDICATORS_DATA', 'update') or current_user.has_module_access('INDICATORS_DATA', 'delete') %}
             <td class="text-end">
-              {% if current_user.has_module_access('configuration', 'update') %}
+              {% if current_user.has_module_access('INDICATORS_DATA', 'update') %}
               <a
                 href="{{ url_for('country_indicator.edit_country_indicator', id=ci.id) }}"
                 class="btn btn-warning btn-sm me-2"
@@ -108,7 +113,7 @@
                 <i class="fas fa-pen"></i>
               </a>
               {% endif %}
-              {% if current_user.has_module_access('configuration', 'delete') %}
+              {% if current_user.has_module_access('INDICATORS_DATA', 'delete') %}
               <a
                 href="{{ url_for('country_indicator.delete_country_indicator', id=ci.id) }}"
                 class="btn btn-danger btn-sm"
@@ -123,7 +128,7 @@
           {% endfor %}
         </tbody>
       </table>
-    {% if current_user.has_module_access('configuration', 'delete') %}
+    {% if current_user.has_module_access('INDICATORS_DATA', 'delete') %}
     </form>
     {% endif %}
   </div>
@@ -232,24 +237,27 @@
         </div>
         <div class="mb-3">
           {{ form.description.label(class="form-label") }}
+          <small class="text-muted ms-1">— {{ _('Deja vacío para usar la descripción del indicador') }}</small>
           {{ form.description(class="form-control") }}
           {% for error in form.description.errors %}
           <div class="text-danger">{{ error }}</div>
           {% endfor %}
         </div>
-        <div class="mb-3">
-          {{ form.store.label(class="form-label") }}
-          {{ form.store(class="form-control") }}
-          {% for error in form.store.errors %}
-          <div class="text-danger">{{ error }}</div>
-          {% endfor %}
-        </div>
-        <div class="mb-3">
-          {{ form.workspace.label(class="form-label") }}
-          {{ form.workspace(class="form-control") }}
-          {% for error in form.workspace.errors %}
-          <div class="text-danger">{{ error }}</div>
-          {% endfor %}
+        <div class="row">
+          <div class="col-6 mb-3">
+            {{ form.store.label(class="form-label") }}
+            {{ form.store(class="form-control") }}
+            {% for error in form.store.errors %}
+            <div class="text-danger">{{ error }}</div>
+            {% endfor %}
+          </div>
+          <div class="col-6 mb-3">
+            {{ form.workspace.label(class="form-label") }}
+            {{ form.workspace(class="form-control") }}
+            {% for error in form.workspace.errors %}
+            <div class="text-danger">{{ error }}</div>
+            {% endfor %}
+          </div>
         </div>
       </div>
       <div class="modal-footer">

--- a/src/app/translations/en_US/LC_MESSAGES/messages.po
+++ b/src/app/translations/en_US/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-26 11:55-0500\n"
+"POT-Creation-Date: 2026-07-01 15:03-0500\n"
 "PO-Revision-Date: 2025-08-05 10:12-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en_US\n"
@@ -90,7 +90,7 @@ msgstr "For Colombia: DANE Divipola Code for department"
 #: app/templates/country_climate_measure/list.html:69
 #: app/templates/country_climate_measure/list.html:276
 #: app/templates/country_indicator/list.html:69
-#: app/templates/country_indicator/list.html:285
+#: app/templates/country_indicator/list.html:293
 #: app/templates/cultivar/list.html:71 app/templates/cultivar/list.html:235
 #: app/templates/data_source/list.html:75
 #: app/templates/data_source/list.html:251 app/templates/home.html:39
@@ -230,7 +230,7 @@ msgstr "Climate variable is required."
 #: app/templates/country_climate_measure/list.html:71
 #: app/templates/country_climate_measure/list.html:288
 #: app/templates/country_indicator/list.html:71
-#: app/templates/country_indicator/list.html:297
+#: app/templates/country_indicator/list.html:305
 msgid "Pronóstico espacial"
 msgstr "Spatial Forecast"
 
@@ -239,7 +239,7 @@ msgstr "Spatial Forecast"
 #: app/templates/country_climate_measure/list.html:72
 #: app/templates/country_climate_measure/list.html:294
 #: app/templates/country_indicator/list.html:72
-#: app/templates/country_indicator/list.html:303
+#: app/templates/country_indicator/list.html:311
 msgid "Clima espacial"
 msgstr "Spatial Climate"
 
@@ -248,7 +248,7 @@ msgstr "Spatial Climate"
 #: app/templates/country_climate_measure/list.html:73
 #: app/templates/country_climate_measure/list.html:300
 #: app/templates/country_indicator/list.html:73
-#: app/templates/country_indicator/list.html:309
+#: app/templates/country_indicator/list.html:317
 msgid "Pronóstico por ubicación"
 msgstr "Forecast by location"
 
@@ -257,7 +257,7 @@ msgstr "Forecast by location"
 #: app/templates/country_climate_measure/list.html:74
 #: app/templates/country_climate_measure/list.html:306
 #: app/templates/country_indicator/list.html:74
-#: app/templates/country_indicator/list.html:315
+#: app/templates/country_indicator/list.html:323
 msgid "Clima por ubicación"
 msgstr "Climate by location"
 
@@ -273,7 +273,7 @@ msgstr "Store"
 #: app/templates/country_climate_measure/list.html:77
 #: app/templates/country_indicator/list.html:78
 msgid "Workspace"
-msgstr ""
+msgstr "Workspace"
 
 #: app/forms/country_form.py:8
 msgid "Nombre del país"
@@ -310,7 +310,7 @@ msgstr "Error validating JSON: "
 
 #: app/forms/country_indicator_form.py:29
 #: app/templates/country_indicator/list.html:70
-#: app/templates/country_indicator/list.html:291
+#: app/templates/country_indicator/list.html:299
 msgid "Indicador"
 msgstr "Indicators"
 
@@ -1063,12 +1063,12 @@ msgid "No tienes permiso para crear relaciones país-indicador."
 msgstr "You don't have permission to create country-indicator relationships."
 
 #: app/routes/country_indicator_routes.py:39
-#: app/routes/country_indicator_routes.py:97
+#: app/routes/country_indicator_routes.py:99
 msgid "El campo Criterios debe ser un objeto JSON válido (diccionario)."
 msgstr "The Criteria field must be a valid JSON object (dictionary)."
 
 #: app/routes/country_indicator_routes.py:43
-#: app/routes/country_indicator_routes.py:100
+#: app/routes/country_indicator_routes.py:102
 msgid ""
 "El campo Criterios contiene un JSON inválido. Por favor, verifica el "
 "formato."
@@ -1562,53 +1562,49 @@ msgstr "Indicator management"
 msgid "Gestión de categorías de indicadores"
 msgstr "Indicator categories management"
 
-#: app/templates/base.html:309 app/templates/base.html:316
+#: app/templates/base.html:294
+msgid "Indicadores por país"
+msgstr "Indicators by country"
+
+#: app/templates/base.html:300
+msgid "Características de indicadores"
+msgstr "Indicator Features"
+
+#: app/templates/base.html:321 app/templates/base.html:328
 #: app/templates/home.html:196 app/templates/home.html:230
 #: app/templates/user/edit.html:13 app/templates/user/list.html:1
 #: app/templates/user/list.html:5
 msgid "Usuarios"
 msgstr "Users"
 
-#: app/templates/base.html:322 app/templates/home.html:212
+#: app/templates/base.html:334 app/templates/home.html:212
 #: app/templates/role/edit.html:13 app/templates/role/list.html:1
 #: app/templates/role/list.html:5
 msgid "Roles"
 msgstr "Roles"
 
-#: app/templates/base.html:340 app/templates/landing.html:338
+#: app/templates/base.html:352 app/templates/landing.html:338
 msgid "Configuración"
 msgstr "Configuration"
 
 #: app/templates/app/edit.html:8 app/templates/app/list.html:2
-#: app/templates/app/list.html:6 app/templates/base.html:350
+#: app/templates/app/list.html:6 app/templates/base.html:362
 msgid "Aplicaciones"
 msgstr "Applications"
 
-#: app/templates/base.html:356 app/templates/source/list.html:2
+#: app/templates/base.html:368 app/templates/source/list.html:2
 #: app/templates/source/list.html:6
 msgid "Fuentes de locaciones"
 msgstr "Locations sources"
 
-#: app/templates/base.html:362
+#: app/templates/base.html:374
 msgid "Parámetros de clientes"
 msgstr "Client parameters "
 
-#: app/templates/base.html:368
-msgid "Indicadores por país"
-msgstr "Indicators by country"
-
-#: app/templates/base.html:374
-msgid "Medidas climáticas por país"
-msgstr "Climate measures by country"
-
-#: app/templates/base.html:380
-msgid "Características de indicadores"
-msgstr "Indicator Features"
-
 #: app/templates/adm1/list.html:169 app/templates/app/list.html:165
-#: app/templates/base.html:431 app/templates/climate_measure/list.html:167
+#: app/templates/base.html:426 app/templates/climate_measure/list.html:167
 #: app/templates/country_climate_measure/list.html:190
-#: app/templates/country_indicator/list.html:192
+#: app/templates/country_indicator/list.html:197
 #: app/templates/cultivar/list.html:167
 #: app/templates/indicator_category/list.html:163
 #: app/templates/indicator_features/list.html:175
@@ -1831,8 +1827,8 @@ msgstr "E.g.: 27 for Chocó"
 #: app/templates/country/list.html:174
 #: app/templates/country_climate_measure/edit.html:74
 #: app/templates/country_climate_measure/list.html:248
-#: app/templates/country_indicator/edit.html:82
-#: app/templates/country_indicator/list.html:257 app/templates/crop/add.html:38
+#: app/templates/country_indicator/edit.html:89
+#: app/templates/country_indicator/list.html:265 app/templates/crop/add.html:38
 #: app/templates/crop/crop_list.html:159 app/templates/crop/edit.html:36
 #: app/templates/crop/list.html:174 app/templates/cultivar/edit.html:61
 #: app/templates/cultivar/list.html:206 app/templates/data_source/add.html:38
@@ -1879,7 +1875,7 @@ msgstr "Administrative Divisions - Level 1 (ADM1)"
 #: app/templates/country_climate_measure/list.html:13
 #: app/templates/country_climate_measure/list.html:250
 #: app/templates/country_indicator/list.html:13
-#: app/templates/country_indicator/list.html:259
+#: app/templates/country_indicator/list.html:267
 #: app/templates/crop/crop_list.html:12 app/templates/crop/crop_list.html:161
 #: app/templates/crop/list.html:13 app/templates/crop/list.html:176
 #: app/templates/cultivar/list.html:13 app/templates/cultivar/list.html:208
@@ -2132,7 +2128,7 @@ msgstr "Disabled"
 #: app/templates/adm1/list.html:105 app/templates/app/list.html:101
 #: app/templates/climate_measure/list.html:103
 #: app/templates/country_climate_measure/list.html:104
-#: app/templates/country_indicator/list.html:106
+#: app/templates/country_indicator/list.html:111
 #: app/templates/cultivar/list.html:105
 #: app/templates/indicator_category/list.html:99
 #: app/templates/indicator_features/list.html:97
@@ -2172,7 +2168,7 @@ msgstr "Recover"
 #: app/templates/app/list.html:137 app/templates/climate_measure/list.html:139
 #: app/templates/country/list.html:124
 #: app/templates/country_climate_measure/list.html:130
-#: app/templates/country_indicator/list.html:132
+#: app/templates/country_indicator/list.html:137
 #: app/templates/crop/crop_list.html:113 app/templates/crop/list.html:127
 #: app/templates/cultivar/list.html:139 app/templates/data_source/list.html:136
 #: app/templates/indicator/list.html:148
@@ -2249,7 +2245,7 @@ msgstr "Edit Application"
 
 #: app/templates/app/list.html:137 app/templates/climate_measure/list.html:139
 #: app/templates/country_climate_measure/list.html:130
-#: app/templates/country_indicator/list.html:132
+#: app/templates/country_indicator/list.html:137
 #: app/templates/crop/crop_list.html:113 app/templates/crop/list.html:127
 #: app/templates/indicator/list.html:148
 #: app/templates/indicator_category/list.html:135
@@ -2386,7 +2382,7 @@ msgid "No"
 msgstr "No"
 
 #: app/templates/country_climate_measure/list.html:113
-#: app/templates/country_indicator/list.html:115
+#: app/templates/country_indicator/list.html:120
 #: app/templates/indicator_features/list.html:106
 #: app/templates/setup/edit.html:76 app/templates/user/permissions.html:132
 msgid "Eliminar"
@@ -2408,23 +2404,35 @@ msgstr "Edit Country-Indicator Relationship"
 msgid "Editar relación país-indicador"
 msgstr "Edit Country-Indicator Relationship"
 
+#: app/templates/country_indicator/edit.html:59
+msgid "Si se deja vacío, se usa la descripción del indicador"
+msgstr "If left blank, the indicator description is used."
+
+#: app/templates/country_indicator/edit.html:62
+msgid "Descripción del indicador:"
+msgstr "Indicator description"
+
 #: app/templates/country_indicator/list.html:2
 #: app/templates/country_indicator/list.html:6
 msgid "Relaciones País-Indicador"
 msgstr "Country-Indicator Relationships"
 
 #: app/templates/country_indicator/list.html:75
-#: app/templates/country_indicator/list.html:321
+#: app/templates/country_indicator/list.html:329
 msgid "Criterios"
 msgstr "Criteria"
 
-#: app/templates/country_indicator/list.html:136
+#: app/templates/country_indicator/list.html:141
 msgid "No hay relaciones país-indicador registradas."
 msgstr "No country-indicator relationships registered."
 
-#: app/templates/country_indicator/list.html:186
+#: app/templates/country_indicator/list.html:191
 msgid "Agregar relación país-indicador"
 msgstr "Add country-indicator relationship"
+
+#: app/templates/country_indicator/list.html:240
+msgid "Deja vacío para usar la descripción del indicador"
+msgstr "Leave blank to use the indicator description."
 
 #: app/templates/crop/add.html:7 app/templates/crop/crop_list.html:135
 #: app/templates/crop/list.html:150
@@ -3939,4 +3947,7 @@ msgstr "Save Changes"
 
 #~ msgid "Actualizar Usuario"
 #~ msgstr "Update User"
+
+#~ msgid "Medidas climáticas por país"
+#~ msgstr "Climate measures by country"
 

--- a/src/app/translations/es_CO/LC_MESSAGES/messages.po
+++ b/src/app/translations/es_CO/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-26 11:55-0500\n"
+"POT-Creation-Date: 2026-07-01 15:03-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es_CO\n"
@@ -90,7 +90,7 @@ msgstr "Para Colombia: Código Divipola DANE del departamento"
 #: app/templates/country_climate_measure/list.html:69
 #: app/templates/country_climate_measure/list.html:276
 #: app/templates/country_indicator/list.html:69
-#: app/templates/country_indicator/list.html:285
+#: app/templates/country_indicator/list.html:293
 #: app/templates/cultivar/list.html:71 app/templates/cultivar/list.html:235
 #: app/templates/data_source/list.html:75
 #: app/templates/data_source/list.html:251 app/templates/home.html:39
@@ -230,7 +230,7 @@ msgstr "La variable climática es obligatoria."
 #: app/templates/country_climate_measure/list.html:71
 #: app/templates/country_climate_measure/list.html:288
 #: app/templates/country_indicator/list.html:71
-#: app/templates/country_indicator/list.html:297
+#: app/templates/country_indicator/list.html:305
 msgid "Pronóstico espacial"
 msgstr "Pronóstico espacial"
 
@@ -239,7 +239,7 @@ msgstr "Pronóstico espacial"
 #: app/templates/country_climate_measure/list.html:72
 #: app/templates/country_climate_measure/list.html:294
 #: app/templates/country_indicator/list.html:72
-#: app/templates/country_indicator/list.html:303
+#: app/templates/country_indicator/list.html:311
 msgid "Clima espacial"
 msgstr "Clima espacial"
 
@@ -248,7 +248,7 @@ msgstr "Clima espacial"
 #: app/templates/country_climate_measure/list.html:73
 #: app/templates/country_climate_measure/list.html:300
 #: app/templates/country_indicator/list.html:73
-#: app/templates/country_indicator/list.html:309
+#: app/templates/country_indicator/list.html:317
 msgid "Pronóstico por ubicación"
 msgstr "Pronóstico por ubicación"
 
@@ -257,7 +257,7 @@ msgstr "Pronóstico por ubicación"
 #: app/templates/country_climate_measure/list.html:74
 #: app/templates/country_climate_measure/list.html:306
 #: app/templates/country_indicator/list.html:74
-#: app/templates/country_indicator/list.html:315
+#: app/templates/country_indicator/list.html:323
 msgid "Clima por ubicación"
 msgstr "Clima por ubicación"
 
@@ -310,7 +310,7 @@ msgstr "Error al validar el JSON: "
 
 #: app/forms/country_indicator_form.py:29
 #: app/templates/country_indicator/list.html:70
-#: app/templates/country_indicator/list.html:291
+#: app/templates/country_indicator/list.html:299
 msgid "Indicador"
 msgstr "Indicador"
 
@@ -1063,12 +1063,12 @@ msgid "No tienes permiso para crear relaciones país-indicador."
 msgstr "No tienes permiso para crear relaciones país-indicador."
 
 #: app/routes/country_indicator_routes.py:39
-#: app/routes/country_indicator_routes.py:97
+#: app/routes/country_indicator_routes.py:99
 msgid "El campo Criterios debe ser un objeto JSON válido (diccionario)."
 msgstr "El campo Criterios debe ser un objeto JSON válido (diccionario)."
 
 #: app/routes/country_indicator_routes.py:43
-#: app/routes/country_indicator_routes.py:100
+#: app/routes/country_indicator_routes.py:102
 msgid ""
 "El campo Criterios contiene un JSON inválido. Por favor, verifica el "
 "formato."
@@ -1562,53 +1562,49 @@ msgstr "Gestión de indicadores"
 msgid "Gestión de categorías de indicadores"
 msgstr "Gestión de categorías de indicadores"
 
-#: app/templates/base.html:309 app/templates/base.html:316
+#: app/templates/base.html:294
+msgid "Indicadores por país"
+msgstr "Indicadores por país"
+
+#: app/templates/base.html:300
+msgid "Características de indicadores"
+msgstr "Características de indicadores"
+
+#: app/templates/base.html:321 app/templates/base.html:328
 #: app/templates/home.html:196 app/templates/home.html:230
 #: app/templates/user/edit.html:13 app/templates/user/list.html:1
 #: app/templates/user/list.html:5
 msgid "Usuarios"
 msgstr "Usuarios"
 
-#: app/templates/base.html:322 app/templates/home.html:212
+#: app/templates/base.html:334 app/templates/home.html:212
 #: app/templates/role/edit.html:13 app/templates/role/list.html:1
 #: app/templates/role/list.html:5
 msgid "Roles"
 msgstr "Roles"
 
-#: app/templates/base.html:340 app/templates/landing.html:338
+#: app/templates/base.html:352 app/templates/landing.html:338
 msgid "Configuración"
 msgstr "Configuración"
 
 #: app/templates/app/edit.html:8 app/templates/app/list.html:2
-#: app/templates/app/list.html:6 app/templates/base.html:350
+#: app/templates/app/list.html:6 app/templates/base.html:362
 msgid "Aplicaciones"
 msgstr "Aplicaciones"
 
-#: app/templates/base.html:356 app/templates/source/list.html:2
+#: app/templates/base.html:368 app/templates/source/list.html:2
 #: app/templates/source/list.html:6
 msgid "Fuentes de locaciones"
 msgstr "Fuentes de locaciones"
 
-#: app/templates/base.html:362
+#: app/templates/base.html:374
 msgid "Parámetros de clientes"
 msgstr "Parámetros de clientes"
 
-#: app/templates/base.html:368
-msgid "Indicadores por país"
-msgstr "Indicadores por país"
-
-#: app/templates/base.html:374
-msgid "Medidas climáticas por país"
-msgstr "Medidas climáticas por país"
-
-#: app/templates/base.html:380
-msgid "Características de indicadores"
-msgstr "Características de indicadores"
-
 #: app/templates/adm1/list.html:169 app/templates/app/list.html:165
-#: app/templates/base.html:431 app/templates/climate_measure/list.html:167
+#: app/templates/base.html:426 app/templates/climate_measure/list.html:167
 #: app/templates/country_climate_measure/list.html:190
-#: app/templates/country_indicator/list.html:192
+#: app/templates/country_indicator/list.html:197
 #: app/templates/cultivar/list.html:167
 #: app/templates/indicator_category/list.html:163
 #: app/templates/indicator_features/list.html:175
@@ -1834,8 +1830,8 @@ msgstr "Ej: 27 para Chocó"
 #: app/templates/country/list.html:174
 #: app/templates/country_climate_measure/edit.html:74
 #: app/templates/country_climate_measure/list.html:248
-#: app/templates/country_indicator/edit.html:82
-#: app/templates/country_indicator/list.html:257 app/templates/crop/add.html:38
+#: app/templates/country_indicator/edit.html:89
+#: app/templates/country_indicator/list.html:265 app/templates/crop/add.html:38
 #: app/templates/crop/crop_list.html:159 app/templates/crop/edit.html:36
 #: app/templates/crop/list.html:174 app/templates/cultivar/edit.html:61
 #: app/templates/cultivar/list.html:206 app/templates/data_source/add.html:38
@@ -1882,7 +1878,7 @@ msgstr "Divisiones administrativas - Nivel 1"
 #: app/templates/country_climate_measure/list.html:13
 #: app/templates/country_climate_measure/list.html:250
 #: app/templates/country_indicator/list.html:13
-#: app/templates/country_indicator/list.html:259
+#: app/templates/country_indicator/list.html:267
 #: app/templates/crop/crop_list.html:12 app/templates/crop/crop_list.html:161
 #: app/templates/crop/list.html:13 app/templates/crop/list.html:176
 #: app/templates/cultivar/list.html:13 app/templates/cultivar/list.html:208
@@ -2135,7 +2131,7 @@ msgstr "Deshabilitado"
 #: app/templates/adm1/list.html:105 app/templates/app/list.html:101
 #: app/templates/climate_measure/list.html:103
 #: app/templates/country_climate_measure/list.html:104
-#: app/templates/country_indicator/list.html:106
+#: app/templates/country_indicator/list.html:111
 #: app/templates/cultivar/list.html:105
 #: app/templates/indicator_category/list.html:99
 #: app/templates/indicator_features/list.html:97
@@ -2175,7 +2171,7 @@ msgstr "Recuperar"
 #: app/templates/app/list.html:137 app/templates/climate_measure/list.html:139
 #: app/templates/country/list.html:124
 #: app/templates/country_climate_measure/list.html:130
-#: app/templates/country_indicator/list.html:132
+#: app/templates/country_indicator/list.html:137
 #: app/templates/crop/crop_list.html:113 app/templates/crop/list.html:127
 #: app/templates/cultivar/list.html:139 app/templates/data_source/list.html:136
 #: app/templates/indicator/list.html:148
@@ -2252,7 +2248,7 @@ msgstr "Editar Aplicación"
 
 #: app/templates/app/list.html:137 app/templates/climate_measure/list.html:139
 #: app/templates/country_climate_measure/list.html:130
-#: app/templates/country_indicator/list.html:132
+#: app/templates/country_indicator/list.html:137
 #: app/templates/crop/crop_list.html:113 app/templates/crop/list.html:127
 #: app/templates/indicator/list.html:148
 #: app/templates/indicator_category/list.html:135
@@ -2389,7 +2385,7 @@ msgid "No"
 msgstr "No"
 
 #: app/templates/country_climate_measure/list.html:113
-#: app/templates/country_indicator/list.html:115
+#: app/templates/country_indicator/list.html:120
 #: app/templates/indicator_features/list.html:106
 #: app/templates/setup/edit.html:76 app/templates/user/permissions.html:132
 msgid "Eliminar"
@@ -2411,23 +2407,35 @@ msgstr "Editar Relación País-Indicador"
 msgid "Editar relación país-indicador"
 msgstr "Editar relación país-indicador"
 
+#: app/templates/country_indicator/edit.html:59
+msgid "Si se deja vacío, se usa la descripción del indicador"
+msgstr "Si se deja vacío, se usa la descripción del indicador"
+
+#: app/templates/country_indicator/edit.html:62
+msgid "Descripción del indicador:"
+msgstr "Descripción del indicador:"
+
 #: app/templates/country_indicator/list.html:2
 #: app/templates/country_indicator/list.html:6
 msgid "Relaciones País-Indicador"
 msgstr "Relaciones País-Indicador"
 
 #: app/templates/country_indicator/list.html:75
-#: app/templates/country_indicator/list.html:321
+#: app/templates/country_indicator/list.html:329
 msgid "Criterios"
 msgstr "Criterios"
 
-#: app/templates/country_indicator/list.html:136
+#: app/templates/country_indicator/list.html:141
 msgid "No hay relaciones país-indicador registradas."
 msgstr "No hay relaciones país-indicador registradas."
 
-#: app/templates/country_indicator/list.html:186
+#: app/templates/country_indicator/list.html:191
 msgid "Agregar relación país-indicador"
 msgstr "Agregar relación país-indicador"
+
+#: app/templates/country_indicator/list.html:240
+msgid "Deja vacío para usar la descripción del indicador"
+msgstr "Deja vacío para usar la descripción del indicador"
 
 #: app/templates/crop/add.html:7 app/templates/crop/crop_list.html:135
 #: app/templates/crop/list.html:150
@@ -3490,7 +3498,7 @@ msgstr "Guardar Permisos"
 #~ msgstr "Cierre de sesión completado"
 
 #~ msgid "Error al actualizar la temporada: {}"
-#~ msgstr ""
+#~ msgstr "Error al actualizar la temporada: {}"
 
 #~ msgid "Admin Panel"
 #~ msgstr "Panel de Administración"
@@ -3972,4 +3980,7 @@ msgstr "Guardar Permisos"
 
 #~ msgid "Actualizar Usuario"
 #~ msgstr "Actualizar Usuario"
+
+#~ msgid "Medidas climáticas por país"
+#~ msgstr "Medidas climáticas por país"
 


### PR DESCRIPTION
Updates country-indicator access checks, sidebar links, and list/edit layouts. Also adds length validation for store/workspace, restores indicator descriptions as the fallback when empty, and fixes the country edit update call.